### PR TITLE
Update the StreamProvider to support downloads from RD

### DIFF
--- a/addon.js
+++ b/addon.js
@@ -11,7 +11,11 @@ const builder = new addonBuilder(getManifest())
 
 builder.defineCatalogHandler((args) => {
     return new Promise((resolve, reject) => {
-        console.log("Request for catalog with args: " + JSON.stringify(args))
+        const debugArgs = structuredClone(args)
+        if (args.config?.DebridApiKey)
+            debugArgs.config.DebridApiKey = '*'.repeat(args.config.DebridApiKey.length)
+        console.log("Request for catalog with args: " + JSON.stringify(debugArgs))
+
         // Request to Debrid Search
         if (args.id == 'debridsearch') {
             if (!((args.config?.DebridProvider && args.config?.DebridApiKey) || args.config?.DebridLinkApiKey)) {
@@ -56,7 +60,11 @@ builder.defineStreamHandler(args => {
             return
         }
 
-        console.log("Request for streams with args: " + JSON.stringify(args))
+        const debugArgs = structuredClone(args)
+        if (args.config?.DebridApiKey)
+            debugArgs.config.DebridApiKey = '*'.repeat(args.config.DebridApiKey.length)
+        console.log("Request for streams with args: " + JSON.stringify(debugArgs))
+
         switch (args.type) {
             case 'movie':
                 StreamProvider.getMovieStreams(args.config, args.type, args.id)

--- a/lib/real-debrid.js
+++ b/lib/real-debrid.js
@@ -3,17 +3,21 @@ import Fuse from 'fuse.js'
 import { isVideo } from './util/extension-util.js'
 import PTT from './util/parse-torrent-title.js'
 import { BadTokenError, AccessDeniedError } from './util/error-codes.js'
+import { FILE_TYPES } from './util/file-types.js'
 import { encode } from 'urlencode'
 
-async function searchTorrents(apiKey, searchKey = null, threshold = 0.3) {
-    console.log("Search torrents with searchKey: " + searchKey)
+async function searchFiles(fileType, apiKey, searchKey, threshold) {
+    console.log("Search " + fileType.description + " with searchKey: " + searchKey)
 
-    const torrentsResults = await listTorrentsParallel(apiKey, 1, 1000)
-    let torrents = torrentsResults.map(torrentsResult => {
-        return toTorrent(torrentsResult)
-    })
-    // console.log("torrents: " + JSON.stringify(torrents))
-    const fuse = new Fuse(torrents, {
+    const files = await listFilesParrallel(fileType, apiKey, 1, 1000)
+    let results = []
+    if (fileType == FILE_TYPES.TORRENTS)
+        results = files.map(result => {return toTorrent(result)})
+    else if (fileType == FILE_TYPES.DOWNLOADS)
+        results = files.map(result => {return toDownload(result)})
+    results.map(result => result.fileType = fileType)
+    // console.log(fileType.description + " " + JSON.stringify(results))
+    const fuse = new Fuse(results, {
         keys: ['info.title'],
         threshold: threshold,
         minMatchCharLength: 2
@@ -25,6 +29,14 @@ async function searchTorrents(apiKey, searchKey = null, threshold = 0.3) {
     } else {
         return []
     }
+}
+
+async function searchTorrents(apiKey, searchKey = null, threshold = 0.3) {
+    return searchFiles(FILE_TYPES.TORRENTS, apiKey, searchKey, threshold)
+}
+
+async function searchDownloads(apiKey, searchKey = null, threshold = 0.3) {
+    return searchFiles(FILE_TYPES.DOWNLOADS, apiKey, searchKey, threshold)
 }
 
 async function getTorrentDetails(apiKey, id) {
@@ -86,10 +98,23 @@ function toTorrent(item) {
     }
 }
 
+function toDownload(item) {
+    return {
+        source: 'realdebrid',
+        id: item.id,
+        url: item.download,
+        name: item.filename,
+        type: 'other',
+        info: PTT.parse(item.filename),
+        size: item.filesize,
+        created: new Date(item.generated),
+    }
+}
+
 async function listTorrents(apiKey, skip = 0) {
     let nextPage = Math.floor(skip / 50) + 1
 
-    let torrents = await listTorrentsParallel(apiKey, nextPage)
+    let torrents = await listFilesParrallel(FILE_TYPES.TORRENTS, apiKey, nextPage)
     const metas = torrents.map(torrent => {
         return {
             id: 'realdebrid:' + torrent.id,
@@ -100,7 +125,7 @@ async function listTorrents(apiKey, skip = 0) {
     return metas || []
 }
 
-async function listTorrentsParallel(apiKey, page = 1, pageSize = 50) {
+async function listFilesParrallel(fileType, apiKey, page = 1, pageSize = 50) {
     const RD = new RealDebridClient(apiKey, {
         params: {
             page: page,
@@ -108,10 +133,17 @@ async function listTorrentsParallel(apiKey, page = 1, pageSize = 50) {
         }
     })
 
-    const torrents = await RD.torrents.get(0, page, pageSize)
-        .catch(err => handleError(err))
-
-    return torrents || []
+    let files = []
+    if (fileType == FILE_TYPES.TORRENTS) {
+        files = await RD.torrents.get(0, page, pageSize)
+           .catch(err => handleError(err))
+    } else if (fileType == FILE_TYPES.DOWNLOADS) {
+        files = await RD.downloads.get(0, page, pageSize)
+            .catch(err => handleError(err))
+        // exclude torrents returned by RD
+        files = files.filter(f => f.host != 'real-debrid.com')
+    }
+    return files
 }
 
 function handleError(err) {
@@ -128,4 +160,4 @@ function accessDeniedError(error) {
     return [9, 20].includes(error && error.code)
 }
 
-export default { listTorrents, searchTorrents, getTorrentDetails, unrestrictUrl }
+export default { listTorrents, searchTorrents, getTorrentDetails, unrestrictUrl, searchDownloads }

--- a/lib/real-debrid.js
+++ b/lib/real-debrid.js
@@ -43,7 +43,7 @@ async function getTorrentDetails(apiKey, id) {
     const RD = new RealDebridClient(apiKey)
 
     return await RD.torrents.info(id)
-        .then(torrent => toTorrentDetails(apiKey, torrent))
+        .then(resp => toTorrentDetails(apiKey, resp.data))
         .catch(err => handleError(err))
 }
 
@@ -82,7 +82,7 @@ async function unrestrictUrl(apiKey, hostUrl) {
     const RD = new RealDebridClient(apiKey)
 
     return RD.unrestrict.link(hostUrl)
-        .then(value => value.download)
+        .then(resp => resp.data.download)
         .catch(err => handleError(err))
 }
 
@@ -133,17 +133,23 @@ async function listFilesParrallel(fileType, apiKey, page = 1, pageSize = 50) {
         }
     })
 
-    let files = []
     if (fileType == FILE_TYPES.TORRENTS) {
-        files = await RD.torrents.get(0, page, pageSize)
-           .catch(err => handleError(err))
-    } else if (fileType == FILE_TYPES.DOWNLOADS) {
-        files = await RD.downloads.get(0, page, pageSize)
+        return await RD.torrents.get(0, page, pageSize)
+            .then(resp => resp.data)
             .catch(err => handleError(err))
-        // exclude torrents returned by RD
-        files = files.filter(f => f.host != 'real-debrid.com')
+    } else if (fileType == FILE_TYPES.DOWNLOADS) {
+        let files = []
+        let finished = false
+        while (!finished) {
+            const resp = await RD.downloads.get(0, page, 50)
+                .catch(err => handleError(err))
+            files.push(...resp.data)
+            finished = resp.status == 204
+            page++
+        }
+        // ignore the torrents returned by the downloads API
+        return files.filter(f => f.host != 'real-debrid.com')
     }
-    return files
 }
 
 function handleError(err) {

--- a/lib/real-debrid.js
+++ b/lib/real-debrid.js
@@ -153,17 +153,18 @@ async function listFilesParrallel(fileType, apiKey, page = 1, pageSize = 50) {
 }
 
 function handleError(err) {
-    if (err && err.code === 8) {
+    const errData = err.response.data
+    if (errData && errData.error_code === 8) {
         return Promise.reject(BadTokenError)
     }
-    if (err && accessDeniedError(err)) {
+    if (errData && accessDeniedError(errData)) {
         return Promise.reject(AccessDeniedError)
     }
     return Promise.reject(err)
 }
 
-function accessDeniedError(error) {
-    return [9, 20].includes(error && error.code)
+function accessDeniedError(errData) {
+    return [9, 20].includes(errData && errData.error_code)
 }
 
 export default { listTorrents, searchTorrents, getTorrentDetails, unrestrictUrl, searchDownloads }

--- a/lib/stream-provider.js
+++ b/lib/stream-provider.js
@@ -197,8 +197,7 @@ function filterDownloadEpisode(download, season, episode) {
 }
 
 function toStream(details, type) {
-    let video = {}
-    let icon = ''
+    let video, icon
     if (details.fileType == FILE_TYPES.DOWNLOADS) {
         icon = '⬇️'
         video = details

--- a/lib/stream-provider.js
+++ b/lib/stream-provider.js
@@ -3,6 +3,7 @@ import DebridLink from './debrid-link.js'
 import RealDebrid from './real-debrid.js'
 import AllDebrid from './all-debrid.js'
 import { BadRequestError } from './util/error-codes.js'
+import { FILE_TYPES } from './util/file-types.js'
 
 const STREAM_NAME_MAP = {
     debridlink: "[DL+] DebridSearch",
@@ -28,9 +29,10 @@ async function getMovieStreams(config, type, id) {
                     .then(torrentDetailsList => {
                         return torrentDetailsList.map(torrentDetails => toStream(torrentDetails))
                     })
-            }            
+            }
         }
     } else if (config.DebridProvider == "RealDebrid") {
+        let results = []
         const torrents = await RealDebrid.searchTorrents(apiKey, searchKey, 0.1)
         if (torrents && torrents.length) {
             const streams = await Promise.all(torrents
@@ -43,9 +45,17 @@ async function getMovieStreams(config, type, id) {
                         Promise.resolve()
                     })
             }))
-
-            return streams.filter(stream => stream)
+            results.push(...streams)
         }
+
+        const downloads = await RealDebrid.searchDownloads(apiKey, searchKey, 0.1)
+        if (downloads && downloads.length) {
+            const streams = await Promise.all(downloads
+                .filter(download => filterYear(download, cinemetaDetails))
+                .map(download => {return toStream(download, type)}))
+            results.push(...streams)
+        }
+        return results.filter(stream => stream)
     } else if (config.DebridProvider == "AllDebrid") {
         const torrents = await AllDebrid.searchTorrents(apiKey, searchKey, 0.1)
         if (torrents && torrents.length) {
@@ -95,6 +105,7 @@ async function getSeriesStreams(config, type, id) {
             }
         }
     } else if (config.DebridProvider == "RealDebrid") {
+        let results = []
         const torrents = await RealDebrid.searchTorrents(apiKey, searchKey, 0.1)
         if (torrents && torrents.length) {
             const streams = await Promise.all(torrents
@@ -111,9 +122,17 @@ async function getSeriesStreams(config, type, id) {
                             Promise.resolve()
                         })
                 }))
-
-            return streams.filter(stream => stream)
+            results.push(...streams)
         }
+
+        const downloads = await RealDebrid.searchDownloads(apiKey, searchKey, 0.1)
+        if (downloads && downloads.length) {
+            const streams = await Promise.all(downloads
+                .filter(download => filterDownloadEpisode(download, season, episode))
+                .map(download => {return toStream(download, type)}))
+            results.push(...streams)
+        }
+        return results.filter(stream => stream)
     } else if (config.DebridProvider == "AllDebrid") {
         const torrents = await AllDebrid.searchTorrents(apiKey, searchKey, 0.1)
         if (torrents && torrents.length) {
@@ -173,16 +192,27 @@ function filterYear(torrent, cinemetaDetails) {
     return true
 }
 
-function toStream(torrentDetails, type) {
-    const video = torrentDetails.videos.sort((a, b) => b.size - a.size) && torrentDetails.videos[0]
+function filterDownloadEpisode(download, season, episode) {
+    return download && download.info.season == season && download.info.episode == episode
+}
 
-    let title = torrentDetails.name
+function toStream(details, type) {
+    let video = {}
+    let icon = ''
+    if (details.fileType == FILE_TYPES.DOWNLOADS) {
+        icon = '⬇️'
+        video = details
+    } else {
+        icon = '💾'
+        video = details.videos.sort((a, b) => b.size - a.size) && details.videos[0]
+    }
+    let title = details.name
     if (type == 'series') {
         title = title + '\n' + video.name
     }
-    title = title + '\n' + '💾 ' + formatSize(video.size)
+    title = title + '\n' + icon + ' ' + formatSize(video.size)
 
-    let name = STREAM_NAME_MAP[torrentDetails.source]
+    let name = STREAM_NAME_MAP[details.source]
     name = name + '\n' + video.info.resolution
 
     return {

--- a/lib/util/file-types.js
+++ b/lib/util/file-types.js
@@ -1,0 +1,6 @@
+const FILE_TYPES = Object.freeze({
+    TORRENTS: Symbol("torrents"),
+    DOWNLOADS: Symbol("downloads")
+})
+
+export { FILE_TYPES }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"parse-torrent-title": "git://github.com/TheBeastLT/parse-torrent-title.git#022408972c2a040f846331a912a6a8487746a654",
 				"premiumize-api": "^1.0.3",
 				"prom-client": "^12.0.0",
-				"real-debrid-api": "git://github.com/TheBeastLT/node-real-debrid.git#d1f7eaa8593b947edbfbc8a92a176448b48ef445",
+				"real-debrid-api": "git://github.com/DavidRayner/node-real-debrid.git#901deb352f058797548dee874dcc8890abaf85b6",
 				"request-ip": "^3.3.0",
 				"stremio-addon-sdk": "^1.6.10",
 				"swagger-stats": "^0.99.7",
@@ -1572,12 +1572,34 @@
 			}
 		},
 		"node_modules/real-debrid-api": {
-			"version": "1.0.1",
-			"resolved": "git+ssh://git@github.com/TheBeastLT/node-real-debrid.git#d1f7eaa8593b947edbfbc8a92a176448b48ef445",
-			"integrity": "sha512-P4eoA7/wvDM6/l06OZYX4CBnIzsTNwebdS6fZ4u6LZ3fcJqTzWz3D63xBDZmfcOca/OeUN4ncFld+KxvrNr0oA==",
+			"version": "1.1.0",
+			"resolved": "git+ssh://git@github.com/DavidRayner/node-real-debrid.git#901deb352f058797548dee874dcc8890abaf85b6",
+			"integrity": "sha512-MrGnFgiAzPxnX5TlS/gl6KwhRyQou3od1+q/snS0KYPylNflKSu9eKr8UEiRkFkfrddU+qvgUmETqXl6Y2Wwng==",
 			"license": "MIT",
 			"dependencies": {
-				"request": "^2.83.0"
+				"axios": "^0.27.2"
+			}
+		},
+		"node_modules/real-debrid-api/node_modules/axios": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+			"integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+			"dependencies": {
+				"follow-redirects": "^1.14.9",
+				"form-data": "^4.0.0"
+			}
+		},
+		"node_modules/real-debrid-api/node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/request": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"parse-torrent-title": "git://github.com/TheBeastLT/parse-torrent-title.git#022408972c2a040f846331a912a6a8487746a654",
 		"premiumize-api": "^1.0.3",
 		"prom-client": "^12.0.0",
-		"real-debrid-api": "git://github.com/TheBeastLT/node-real-debrid.git#d1f7eaa8593b947edbfbc8a92a176448b48ef445",
+		"real-debrid-api": "git://github.com/DavidRayner/node-real-debrid.git#901deb352f058797548dee874dcc8890abaf85b6",
 		"request-ip": "^3.3.0",
 		"stremio-addon-sdk": "^1.6.10",
 		"swagger-stats": "^0.99.7",


### PR DESCRIPTION
This tackles part of #9 by returning downloads from RealDebrid in the StreamProvider.  
I introduced a `FILE_TYPES` enum to try to avoid duplicating lots of code.

Tested for a series (top hit is a torrent and bottom is a download)
![series](https://github.com/MrMonkey42/stremio-addon-debrid-search/assets/9212074/b8caf669-12da-43b9-87f1-1348185bb9e1)

and for a movie
![mov](https://github.com/MrMonkey42/stremio-addon-debrid-search/assets/9212074/3f82c915-4890-499c-b998-230d94c4ff53)

It is running here if you want to test it: [stremio-addon-debrid-search-0ztf.onrender.com](https://stremio-addon-debrid-search-0ztf.onrender.com/)